### PR TITLE
Added hyperlinking to table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ AsyncAndroid is a community project to publish developer-created content.
 
 # Table of Contents
 
-- [Where to Find Us](https://github.com/AsyncAndroid/async-android/blob/master/README.md#where-to-find-us])
+- [Where to Find Us](https://github.com/AsyncAndroid/async-android/blob/master/README.md#where-to-find-us)
 - [How We Post Content](https://github.com/AsyncAndroid/async-android/blob/master/README.md#how-we-post-content)
 - [How to Contribute](https://github.com/AsyncAndroid/async-android/blob/master/README.md#how-to-contribute)
   - [AsyncAndroid Submmission Checklist](https://github.com/AsyncAndroid/async-android/blob/master/README.md#asyncandroid-submission-checklist)
@@ -99,7 +99,8 @@ Please feel free always to reach out for help. If you need specific help with a 
 # Other Resources
 
 Add video thumbnails | YouTube Help
-https://support.google.com/youtube/answer/72431?hl=en
+https://support.google.com/youtube/answer/72431
 
 Video and audio formatting specifications | YouTube Help
-https://support.google.com/youtube/answer/4603579?hl=en
+https://support.google.com/youtube/answer/4603579
+


### PR DESCRIPTION
Hi, when reading the README, I noticed that the Markdown links were not displaying appropriately. I believe the intended behavior was for the items to be hyperlinked, so I fixed the syntax to allow for links to work!